### PR TITLE
Bugfix: Use onClick defined in options on clicking labels

### DIFF
--- a/public/extensions/IconMarkupExtension/contents/main.js
+++ b/public/extensions/IconMarkupExtension/contents/main.js
@@ -109,7 +109,7 @@ class IconMarkupExtension extends Autodesk.Viewing.Extension {
             </label>
             `);
             $label.css('display', this.viewer.isNodeVisible(icon.dbId) ? 'block' : 'none');
-            $label.on('click', onClick);
+            $label.on('click', this.options.onClick || onClick);
             $viewer.append($label);
 
             // now collect the fragIds


### PR DESCRIPTION
The documentation of IconMarkupExtension shows defining onClick handler in extension options, but this handler was not being used in IconMarkups.